### PR TITLE
Fix JavaMatcher empty match handling

### DIFF
--- a/choppa/iterators.py
+++ b/choppa/iterators.py
@@ -80,6 +80,10 @@ class AccurateSrxTextIterator(AbstractTextIterator):
                 matcher: RuleMatcher = RuleMatcher(
                     document=document, rule=rule, text=text, max_lookaround_len=max_lookbehind_construct_length
                 )
+
+                if not rule.is_break:
+                    matcher.before_matcher.use_transparent_bounds = True
+
                 self.rule_matcher_list.append(matcher)
 
     def __next__(self) -> str:

--- a/choppa/rule_matcher.py
+++ b/choppa/rule_matcher.py
@@ -50,6 +50,13 @@ class JavaMatcher:
             # System.out.println(beforeMatcher.lookingAt());
 
             match = method(self._text[self._start : min(self._start + self.max_lookaround_len, self._end)])
+
+            if match is not None:
+                self.start = self._start + match.start()
+                self.end = self._start + match.end()
+
+                self.region(self._start + max(match.end(), 1))
+
         else:
             for match in self.pattern.finditer(
                 self._text,
@@ -71,18 +78,11 @@ class JavaMatcher:
             else:
                 match = None
 
-        if match is not None:
-            # Moving to the remainder
-            # Also special case for empty matchers
-
-            if not self.use_transparent_bounds:
-                self.start = self._start + match.start()
-                self.end = self._start + match.end()
-            else:
+            if match is not None:
                 self.start = match.start()
                 self.end = match.end()
 
-            self.region(self._start + match.end() + (1 if match.start() == match.end() else 0))
+                self.region(match.end() + max(match.end() - match.start(), 1))
 
         return match
 

--- a/tests/test_rule_matcher.py
+++ b/tests/test_rule_matcher.py
@@ -95,6 +95,59 @@ class RuleMatcherTest(unittest.TestCase):
         match = matcher.find()
         self.assertEqual(match, None)
 
+    def test_java_matcher_only_lookbehind(self):
+        matcher: JavaMatcher = JavaMatcher(pattern=r"(?<=1)", text="111")
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 1)
+        self.assertEqual(matcher.end, 1)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 2)
+        self.assertEqual(matcher.end, 2)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 3)
+        self.assertEqual(matcher.end, 3)
+
+        match = matcher.find()
+        self.assertEqual(match, None)
+
+    def test_java_matcher_only_lookbehind_multimatch(self):
+        matcher: JavaMatcher = JavaMatcher(pattern=r"(?<=[\h\v][A-Z]\.[\h\v]{0,10})", text="Aaaa A. B. , Bbbbb A. B.")
+        matcher.use_transparent_bounds = True
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 7)
+        self.assertEqual(matcher.end, 7)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 8)
+        self.assertEqual(matcher.end, 8)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 10)
+        self.assertEqual(matcher.end, 10)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 11)
+        self.assertEqual(matcher.end, 11)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 21)
+        self.assertEqual(matcher.end, 21)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 22)
+        self.assertEqual(matcher.end, 22)
+
+        match = matcher.find()
+        self.assertEqual(matcher.start, 24)
+        self.assertEqual(matcher.end, 24)
+
+        match = matcher.find()
+        self.assertEqual(match, None)
+
     def test_caret_matcher(self):
         # Emulates behavior of the Java matcher, when
         # caret matcher can match the beginning of the region


### PR DESCRIPTION
There was an issue with empty match handling. It needs to consider the transparent and non-transparent bounds scenario.