### PR TITLE
Implement simple rule matcher

### DIFF
--- a/choppa/iterators.py
+++ b/choppa/iterators.py
@@ -4,7 +4,7 @@ from typing import List, Union, Optional
 
 from .structures import LanguageRule, Rule
 from .srx_parser import SrxDocument
-from .rule_matcher import RuleMatcher, JavaMatcher
+from .rule_matcher import RuleMatcher, JavaMatcher, SimpleRuleMatcher
 from .text_manager import TextManager
 from .rule_manager import RuleManager
 from .utils import create_lookbehind_pattern
@@ -77,9 +77,7 @@ class AccurateSrxTextIterator(AbstractTextIterator):
                         after_pattern=rule.after_pattern,
                     )
 
-                matcher: RuleMatcher = RuleMatcher(
-                    document=document, rule=rule, text=text, max_lookaround_len=max_lookbehind_construct_length
-                )
+                matcher: RuleMatcher = SimpleRuleMatcher(document=document, rule=rule, text=text)
                 self.rule_matcher_list.append(matcher)
 
     def __next__(self) -> str:

--- a/tests/test_rule_matcher.py
+++ b/tests/test_rule_matcher.py
@@ -1,5 +1,5 @@
 import unittest
-from choppa.rule_matcher import RuleMatcher, JavaMatcher
+from choppa.rule_matcher import RuleMatcher, JavaMatcher, SimpleRuleMatcher
 from choppa.srx_parser import SrxDocument, Rule
 
 
@@ -196,3 +196,65 @@ class RuleMatcherTest(unittest.TestCase):
         matcher.region(806)
         match = matcher.find()
         self.assertIsNone(match)
+
+    def test_simple_rule_matcher(self):
+        document: SrxDocument = SrxDocument()
+        rule: Rule = Rule(True, "ab+", "ca+")
+        text: text = "abaabbcabcabcaa"
+        matcher: RuleMatcher = SimpleRuleMatcher(document, rule, text)
+        self.assertFalse(matcher.hit_end())
+        self.assertTrue(matcher.find())
+        self.assertFalse(matcher.hit_end())
+        self.assertEqual(3, matcher.get_start_position())
+        self.assertEqual(6, matcher.get_break_position())
+        self.assertEqual(8, matcher.get_end_position())
+        self.assertTrue(matcher.find())
+        self.assertFalse(matcher.hit_end())
+        self.assertEqual(7, matcher.get_start_position())
+        self.assertEqual(9, matcher.get_break_position())
+        self.assertEqual(11, matcher.get_end_position())
+        self.assertTrue(matcher.find())
+        self.assertFalse(matcher.hit_end())
+        self.assertEqual(10, matcher.get_start_position())
+        self.assertEqual(12, matcher.get_break_position())
+        self.assertEqual(15, matcher.get_end_position())
+        self.assertFalse(matcher.find())
+        self.assertTrue(matcher.hit_end())
+        self.assertTrue(matcher.find(6))
+        self.assertEqual(7, matcher.get_start_position())
+        self.assertEqual(9, matcher.get_break_position())
+        self.assertEqual(11, matcher.get_end_position())
+
+    def test_simple_rule_matcher_zero_length(self):
+        document: SrxDocument = SrxDocument()
+        rule: Rule = Rule(True, "(?<=[A-Z]\\.\\s?)", "")
+        text: text = "XA. B."
+        matcher: RuleMatcher = SimpleRuleMatcher(document, rule, text)
+
+        self.assertFalse(matcher.hit_end())
+
+        self.assertTrue(matcher.find())
+        self.assertFalse(matcher.hit_end())
+        self.assertEqual(3, matcher.get_start_position())
+        self.assertEqual(3, matcher.get_break_position())
+        self.assertEqual(3, matcher.get_end_position())
+
+        self.assertTrue(matcher.find())
+        self.assertFalse(matcher.hit_end())
+        self.assertEqual(4, matcher.get_start_position())
+        self.assertEqual(4, matcher.get_break_position())
+        self.assertEqual(4, matcher.get_end_position())
+
+        self.assertTrue(matcher.find())
+        self.assertFalse(matcher.hit_end())
+        self.assertEqual(6, matcher.get_start_position())
+        self.assertEqual(6, matcher.get_break_position())
+        self.assertEqual(6, matcher.get_end_position())
+
+        self.assertFalse(matcher.find())
+        self.assertTrue(matcher.hit_end())
+
+        self.assertTrue(matcher.find(2))
+        self.assertEqual(3, matcher.get_start_position())
+        self.assertEqual(3, matcher.get_break_position())
+        self.assertEqual(3, matcher.get_end_position())


### PR DESCRIPTION
This is an alternative solution which is getting rid of JavaMatcher in accurate algorithm. Te behavior is not identical as in Java as we discussed [here](https://github.com/loomchild/segment/issues/22#issuecomment-1222314275), but I still fail to see how it will negatively impact real-life segmentation. I don't know what users are trying to achieve by adding `^` to the rule, and if there's a reason, then Python behavior makes more sense to me than Java's. This implementation is simpler, faster, and all tests still succeed.